### PR TITLE
Fixed issue where plugin wouldn't install on 22.11

### DIFF
--- a/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950.pm
+++ b/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950.pm
@@ -16,14 +16,14 @@ use Digest::MD5 qw( md5_hex );
 use MIME::Base64 qw( decode_base64 );
 use URI::Escape qw ( uri_unescape );
 
-our $VERSION = "1.0.9";
+our $VERSION = "1.1.0";
 
 our $metadata = {
     name            => 'ILL availability - z39.50',
     author          => 'Andrew Isherwood',
     date_authored   => '2019-06-24',
     date_updated    => "2023-05-10",
-    minimum_version => '18.11.00.000',
+    minimum_version => '22.11.00.000',
     maximum_version => undef,
     version         => $VERSION,
     description     => 'This plugin provides ILL availability searching for z39.50 targets'

--- a/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950/Api.pm
+++ b/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950/Api.pm
@@ -83,7 +83,7 @@ sub search {
     }
 
     # Now get the full details of each target
-    my $servers = get_z_targets(\@targets_to_search);
+    my $servers = $plugin->get_z_targets(\@targets_to_search);
 
     # Try and calculate what page we're on
     my $page = $start == 0 ? 1 : floor($start / $pageLength) + 1;
@@ -297,18 +297,6 @@ sub get_opac_url {
         $result->{opac_url} = $opac;
     }
     return $result;
-}
-
-sub get_z_targets {
-    my ( $ids ) = @_;
-
-    my $where = $ids ? { id => $ids } : {};
-    # Get the details of the servers we're querying
-    # We may be filtering based on the server IDs we've been passed
-    my $schema = Koha::Database->new()->schema();
-    my $rs = $schema->resultset('Z3950server')->search($where);
-    my @servers = $rs->all;
-    return \@servers;
 }
 
 # Contained MockTemplate object is a compatability shim used so we can pass

--- a/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950/Api.pm
+++ b/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950/Api.pm
@@ -82,7 +82,7 @@ sub search {
     }
 
     # Now get the full details of each target
-    my $servers = $plugin->get_z_targets(\@targets_to_search);
+    my $servers = Koha::Plugin::Com::PTFSEurope::AvailabilityZ3950::get_z_targets(\@targets_to_search);
 
     # Try and calculate what page we're on
     my $page = $start == 0 ? 1 : floor($start / $pageLength) + 1;

--- a/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950/Api.pm
+++ b/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950/Api.pm
@@ -26,7 +26,6 @@ use POSIX;
 use Mojo::Base 'Mojolicious::Controller';
 use C4::Context;
 use C4::Breeding qw( Z3950Search );
-use C4::Items qw( GetHiddenItemnumbers  );
 use Koha::Biblio;
 use Koha::Database;
 use Koha::Plugin::Com::PTFSEurope::AvailabilityZ3950;


### PR DESCRIPTION
* Moved get_z_targets to main module, from Api.pm
* Re-referenced get_z_targets in Api.pm to main module
* Removed reference to Api module from main module
* The plugin now works on 22.11