### PR TITLE
Removed obsolete pragma reference for 22.11

### DIFF
--- a/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950.pm
+++ b/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950.pm
@@ -17,14 +17,14 @@ use Digest::MD5 qw( md5_hex );
 use MIME::Base64 qw( decode_base64 );
 use URI::Escape qw ( uri_unescape );
 
-our $VERSION = "1.0.8";
+our $VERSION = "1.0.9";
 
 our $metadata = {
     name            => 'ILL availability - z39.50',
     author          => 'Andrew Isherwood',
     date_authored   => '2019-06-24',
-    date_updated    => "2020-05-26",
-    minimum_version => '18.11.00.000',
+    date_updated    => '2023-05-10',
+    minimum_version => '22.11.00.000',
     maximum_version => undef,
     version         => $VERSION,
     description     => 'This plugin provides ILL availability searching for z39.50 targets'

--- a/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950/Api.pm
+++ b/Koha/Plugin/Com/PTFSEurope/AvailabilityZ3950/Api.pm
@@ -26,7 +26,6 @@ use POSIX;
 use Mojo::Base 'Mojolicious::Controller';
 use C4::Context;
 use C4::Breeding qw( Z3950Search );
-use C4::Items qw( GetHiddenItemnumbers  );
 use Koha::Biblio;
 use Koha::Database;
 use Koha::Plugin::Com::PTFSEurope::AvailabilityZ3950;


### PR DESCRIPTION
This removes an old pragma use that was causing Koha >= 22.11 to refuse to install or run the plugin

This class / method pragma never appears to actually get called in the code, so it should be a safe patch for older versions, too

That said, the version has been bumped to 22.11 just in case 